### PR TITLE
changed a way to create customEvent to prevent having error on IE10 on Win8.

### DIFF
--- a/lib/WebMIDIAPI.js
+++ b/lib/WebMIDIAPI.js
@@ -268,7 +268,8 @@
   }
 
   function _midiProc( timestamp, data ) {
-    var evt = new CustomEvent( "message" );
+    var evt = document.createEvent( "Event" );
+    evt.initEvent( "cutonEvent", false, false );
     evt.timestamp = parseFloat( timestamp.toString()) + this._jazzInstance._perfTimeZero;
     var length = 0;
     var i,j;


### PR DESCRIPTION
Change from
 var evt = new CustomEvent( "message" );
to
 var evt = document.createEvent( "Event" );
to avoid error(below) in IE10(10.0.9200.16384) on Windows8

------ >8 ---[Error from IE10 on Win8]--- >8 ------
 SCRIPT445: Object doesn't support this action
 WebMIDIAPI.js, line 271 character 5
------ >8 --------------------- >8 ------
