### PR TITLE
Fixing Sysex buffering

### DIFF
--- a/WebMIDIAPI.js
+++ b/WebMIDIAPI.js
@@ -303,7 +303,7 @@
             evt.receivedTime = parseFloat( timestamp.toString()) + this._jazzInstance._perfTimeZero;
             if (isSysexMessage || this._inLongSysexMessage) {
                 evt.data = new Uint8Array( this._sysexBuffer );
-                this._sysexBuffer.length = 0;
+                this._sysexBuffer = Uint8Array(0);
                 this._inLongSysexMessage = false;
             } else
                 evt.data = new Uint8Array(data.slice(i, length+i));


### PR DESCRIPTION
The original code tries to truncate the Sysex buffer by setting the
length to 0. But since it is a typed array, this will either not work
(Firefox) or error out (Chrome).

Fixes #37
