### PR TITLE
rename variable ev.timestamp to ev.timeStamp to fix undefined error in t...

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
     <p class="copyright">Web MIDI API Polyfill maintained by <a href="https://github.com/cwilso">cwilso</a></p>
   </footer>
     </div>
-<script src="WebMIDIAPI.js"></script> 
+<script src="WebMIDIAPI.js"></script>
 <script>
 var midi=null;
 var inputs=null;
@@ -66,8 +66,8 @@ function runTest() {
 
 function handleMIDIMessage( ev ) {
 	// testing - just reflect.
-	log.innerHTML += "Message: " + ev.data.length + " bytes, timestamp: " + ev.timestamp;
-	if (ev.data.length == 3) 
+	log.innerHTML += "Message: " + ev.data.length + " bytes, timestamp: " + ev.timeStamp;
+	if (ev.data.length == 3)
 		log.innerHTML += " 0x" + ev.data[0].toString(16) + " 0x" + ev.data[1].toString(16) + " 0x" + ev.data[2].toString(16);
 	log.innerHTML += "\n";
 	if (output)


### PR DESCRIPTION
The handleMidiMessage(ev) function, the ev object generated by a midi input event contains the variable ev.timeStamp, the test had it as ev.timestamp and it was producing an undefined error in the midi test output.

Phenomenal library btw! Thank you so much for this.
