### PR TITLE
Shim updated according to the latest W3C draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,45 @@
 # Web MIDI API Polyfill
 
 This JS library is a prototype polyfill and shim for the [Web MIDI API](http://webaudio.github.io/web-midi-api/) (of which Chris is a co-author), using [Jazz-Soft.net's Jazz-Plugin](http://jazz-soft.net/) to enable MIDI support on Windows, OSX and Linux.
-You need to have [version 1.2 or hgher](http://jazz-soft.net/download/Jazz-Plugin) of the Jazz-Plugin in order for this polyfill to work properly.  This polyfill and the plugin should work on Chrome, Firefox, Safari, Opera and IE.
+You need to have [version 1.2 or higher](http://jazz-soft.net/download/Jazz-Plugin) of the Jazz-Plugin in order for this polyfill to work properly. This polyfill and the plugin should work on Chrome, Firefox, Safari, Opera and IE.
 
 This polyfill was originally designed to test usability of the API itself, but it's also useful to enable MIDI scenarios in browsers that don't yet support Web MIDI.
 
-This polyfill now supports multiple simultaneous inputs and outputs, and sending and receiving long messages (sysem exclusive).  It also properly dispatches events.  Timestamps on send and receive should be properly implemented now, although of course timing will not be very precise on either.
+This polyfill now supports multiple simultaneous inputs and outputs, and sending and receiving long messages (sysem exclusive). It also properly dispatches events. Timestamps on send and receive should be properly implemented now, although of course timing will not be very precise on either.
 
 ##Usage
 
 1. Copy the WebMIDIAPI.js file from /lib/ into your project.
 2. Add "&lt;script src='lib/WebMIDIAPI.js'>&lt;/script>" to your code.
 
-You can use the Web MIDI API as captured in the specification  - the polyfill will automatically check to see if the Web MIDI API is already implemented, and if not it will insert itself.
+You can use the Web MIDI API as captured in the specification - the polyfill will automatically check to see if the Web MIDI API is already implemented, and if not it will insert itself.
 
 So, some sample usage:
 
-	var m = null;   // m = MIDIAccess object for you to make calls on
+	var m = null; // m = MIDIAccess object for you to make calls on
     navigator.requestMIDIAccess().then( onsuccesscallback, onerrorcallback );
 
     function onsuccesscallback( access ) {
     	m = access;
 
     	// Things you can do with the MIDIAccess object:
-	    var inputs = m.inputs();   // inputs = array of MIDIPorts
-	    var outputs = m.outputs(); // outputs = array of MIDIPorts
-	    inputs[0].onmidimessage = myMIDIMessagehandler;	// onmidimessage( event ), event.data & event.receivedTime are populated
-	    var o = m.outputs()[0];           // grab first output device
-	    o.send( [ 0x90, 0x45, 0x7f ] );     // full velocity note on A4 on channel zero
-	    o.send( [ 0x80, 0x45, 0x7f ], window.performance.now() + 1000 );  // full velocity A4 note off in one second.
+	    var inputs = m.inputs; // inputs = MIDIInputMaps, you can retrieve the inputs with iterators
+	    var outputs = m.outputs; // outputs = MIDIOutputMaps, you can retrieve the outputs with iterators
+
+      var iteratorInputs = inputs.values() // returns an iterator that loops over all inputs
+      var input = iteratorInputs.next().value // get the first input
+
+      input.onmidimessage = myMIDIMessagehandler; // onmidimessage( event ), event.data & event.receivedTime are populated
+
+      var iteratorOutputs = outputs.values() // returns an iterator that loops over all outputs
+      var output = iteratorOutputs.next().value; // grab first output device
+
+      output.send( [ 0x90, 0x45, 0x7f ] ); // full velocity note on A4 on channel zero
+	    output.send( [ 0x80, 0x45, 0x7f ], window.performance.now() + 1000 );  // full velocity A4 note off in one second.
 	};
 
 	function onerrorcallback( err ) {
-		console.log("uh-oh! Something went wrong!  Error code: " + err.code );
+		console.log( "uh-oh! Something went wrong!  Error code: " + err.code );
 	}
 
 You can also take a look at [index.html](http://cwilso.github.com/WebMIDIAPIShim/tests/index.html) for a basic test, or [multi.html](http://cwilso.github.com/WebMIDIAPIShim/tests/multi.html) or [routing.html](http://cwilso.github.com/WebMIDIAPIShim/tests/routing.html) for a multiple-simultaneous-input test.  Better documentation later.  :)
@@ -45,34 +52,35 @@ You can also take a look at [index.html](http://cwilso.github.com/WebMIDIAPIShim
 
     var navigator = require('web-midi-api');
 
-    var ins;
-    var outs;
+    var midi;
+    var inputs;
+    var outputs;
 
     function onMIDIFailure(msg){
-      console.log("Failed to get MIDI access - " + msg);
+      console.log('Failed to get MIDI access - ' + msg);
     }
 
     function onMIDISuccess(midiAccess){
       midi = midiAccess;
-      ins = midi.inputs();
-      outs = midi.outputs();
-      setTimeout(testOutputs, 200);
+      inputs = midi.inputs;
+      outputs = midi.outputs;
+      setTimeout(testOutputs, 500);
     }
 
     function testOutputs(){
       console.log('Testing MIDI-Out ports...');
-      for(var i in outs){
-        var x = outs[i];
-        console.log('id:', x.id, "manufacturer:", x.manufacturer, "name:", x.name, "version:", x.version);
+      outputs.forEach(function(key, value){
+        var x = value;
+        console.log('id:', x.id, 'manufacturer:', x.manufacturer, 'name:', x.name, 'version:', x.version);
         x.send([0x90, 60, 0x7f]);
-      }
+      });
       setTimeout(stopOutputs, 1000);
     }
 
     function stopOutputs(){
-      for(var i in outs){
-        outs[i].send([0x80, 60, 0]);
-      }
+      outputs.forEach(function(key, value){
+        value.send([0x80, 60, 0]);
+      });
       testInputs();
     }
 
@@ -84,11 +92,11 @@ You can also take a look at [index.html](http://cwilso.github.com/WebMIDIAPIShim
 
     function testInputs(){
       console.log('Testing MIDI-In ports...');
-      for(var i in ins){
-        var x = ins[i];
-        console.log('id:', x.id, "manufacturer:", x.manufacturer, "name:", x.name, "version:", x.version);
+      inputs.forEach(function(key, value){
+        var x = value;
+        console.log('id:', x.id, 'manufacturer:', x.manufacturer, 'name:', x.name, 'version:', x.version);
         x.onmidimessage = onMidiIn;
-      }
+      });
       setTimeout(stopInputs, 5000);
     }
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ So, some sample usage:
 		console.log("uh-oh! Something went wrong!  Error code: " + err.code );
 	}
 
-You can also take a look at [index.html](http://cwilso.github.com/WebMIDIAPIShim/tests/index.html) for a basic test, or [multi.html](http://cwilso.github.com/WebMIDIAPIShim/tests/multi.html) for a multiple-simultaneous-input test.  Better documentation later.  :)
+You can also take a look at [index.html](http://cwilso.github.com/WebMIDIAPIShim/tests/index.html) for a basic test, or [multi.html](http://cwilso.github.com/WebMIDIAPIShim/tests/multi.html) or [routing.html](http://cwilso.github.com/WebMIDIAPIShim/tests/routing.html) for a multiple-simultaneous-input test.  Better documentation later.  :)
 
 ##Node.js install
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Web MIDI API Polyfill
 
-This JS library is a prototype polyfill and shim for the [Web MIDI API](http://webaudio.github.io/web-midi-api/#midiinputmap-interface) (of which Chris is a co-author), using [Jazz-Soft.net's Jazz-Plugin](http://jazz-soft.net/) to enable MIDI support on Windows, OSX and Linux.
+This JS library is a prototype polyfill and shim for the [Web MIDI API](http://webaudio.github.io/web-midi-api/) (of which Chris is a co-author), using [Jazz-Soft.net's Jazz-Plugin](http://jazz-soft.net/) to enable MIDI support on Windows, OSX and Linux.
 You need to have [version 1.2 or hgher](http://jazz-soft.net/download/Jazz-Plugin) of the Jazz-Plugin in order for this polyfill to work properly.  This polyfill and the plugin should work on Chrome, Firefox, Safari, Opera and IE.
 
 This polyfill was originally designed to test usability of the API itself, but it's also useful to enable MIDI scenarios in browsers that don't yet support Web MIDI.

--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ You can use the Web MIDI API as captured in the specification - the polyfill wil
 
 So, some sample usage:
 
-	var m = null; // m = MIDIAccess object for you to make calls on
+    var m = null; // m = MIDIAccess object for you to make calls on
     navigator.requestMIDIAccess().then( onsuccesscallback, onerrorcallback );
 
     function onsuccesscallback( access ) {
-    	m = access;
+      m = access;
 
-    	// Things you can do with the MIDIAccess object:
-	    var inputs = m.inputs; // inputs = MIDIInputMaps, you can retrieve the inputs with iterators
-	    var outputs = m.outputs; // outputs = MIDIOutputMaps, you can retrieve the outputs with iterators
+      // Things you can do with the MIDIAccess object:
+      var inputs = m.inputs; // inputs = MIDIInputMaps, you can retrieve the inputs with iterators
+      var outputs = m.outputs; // outputs = MIDIOutputMaps, you can retrieve the outputs with iterators
 
       var iteratorInputs = inputs.values() // returns an iterator that loops over all inputs
       var input = iteratorInputs.next().value // get the first input
@@ -35,12 +35,12 @@ So, some sample usage:
       var output = iteratorOutputs.next().value; // grab first output device
 
       output.send( [ 0x90, 0x45, 0x7f ] ); // full velocity note on A4 on channel zero
-	    output.send( [ 0x80, 0x45, 0x7f ], window.performance.now() + 1000 );  // full velocity A4 note off in one second.
-	};
+      output.send( [ 0x80, 0x45, 0x7f ], window.performance.now() + 1000 ); // full velocity A4 note off in one second.
+    };
 
-	function onerrorcallback( err ) {
-		console.log( "uh-oh! Something went wrong!  Error code: " + err.code );
-	}
+    function onerrorcallback( err ) {
+      console.log( "uh-oh! Something went wrong! Error code: " + err.code );
+    }
 
 You can also take a look at [index.html](http://cwilso.github.com/WebMIDIAPIShim/tests/index.html) for a basic test, or [multi.html](http://cwilso.github.com/WebMIDIAPIShim/tests/multi.html) or [routing.html](http://cwilso.github.com/WebMIDIAPIShim/tests/routing.html) for a multiple-simultaneous-input test.  Better documentation later.  :)
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ So, some sample usage:
       console.log( "uh-oh! Something went wrong! Error code: " + err.code );
     }
 
-You can also take a look at [index.html](http://cwilso.github.com/WebMIDIAPIShim/tests/index.html) for a basic test, or [multi.html](http://cwilso.github.com/WebMIDIAPIShim/tests/multi.html) or [routing.html](http://cwilso.github.com/WebMIDIAPIShim/tests/routing.html) for a multiple-simultaneous-input test.  Better documentation later.  :)
+You can also take a look at [index.html](http://cwilso.github.com/WebMIDIAPIShim/tests/index.html) for a basic test, or [multi.html](http://cwilso.github.com/WebMIDIAPIShim/tests/multi.html) for a multiple-simultaneous-input test. The [routing.html](http://cwilso.github.com/WebMIDIAPIShim/tests/routing.html) example mimics a MIDI patchbay and allows you to route one or more inputs to one or more outputs. Better documentation later.  :)
 
 ##Node.js install and test
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Web MIDI API Polyfill
 
-This JS library is a prototype polyfill and shim for the [Web MIDI API](https://dvcs.w3.org/hg/audio/raw-file/tip/midi/specification.html) (of which Chris is a co-author), using [Jazz-Soft.net's Jazz-Plugin](http://jazz-soft.net/) to enable MIDI support on Windows, OSX and Linux.
+This JS library is a prototype polyfill and shim for the [Web MIDI API](http://webaudio.github.io/web-midi-api/#midiinputmap-interface) (of which Chris is a co-author), using [Jazz-Soft.net's Jazz-Plugin](http://jazz-soft.net/) to enable MIDI support on Windows, OSX and Linux.
 You need to have [version 1.2 or hgher](http://jazz-soft.net/download/Jazz-Plugin) of the Jazz-Plugin in order for this polyfill to work properly.  This polyfill and the plugin should work on Chrome, Firefox, Safari, Opera and IE.
 
 This polyfill was originally designed to test usability of the API itself, but it's also useful to enable MIDI scenarios in browsers that don't yet support Web MIDI.
@@ -9,17 +9,17 @@ This polyfill now supports multiple simultaneous inputs and outputs, and sending
 
 ##Usage
 
-1. Copy the WebMIDIAPI.js file from /lib/ into your project.  
+1. Copy the WebMIDIAPI.js file from /lib/ into your project.
 2. Add "&lt;script src='lib/WebMIDIAPI.js'>&lt;/script>" to your code.
 
 You can use the Web MIDI API as captured in the specification  - the polyfill will automatically check to see if the Web MIDI API is already implemented, and if not it will insert itself.
 
-So, some sample usage: 
+So, some sample usage:
 
 	var m = null;   // m = MIDIAccess object for you to make calls on
     navigator.requestMIDIAccess().then( onsuccesscallback, onerrorcallback );
-    
-    function onsuccesscallback( access ) { 
+
+    function onsuccesscallback( access ) {
     	m = access;
 
     	// Things you can do with the MIDIAccess object:
@@ -44,21 +44,21 @@ You can also take a look at [index.html](http://cwilso.github.com/WebMIDIAPIShim
 ##Node.js example
 
     var navigator = require('web-midi-api');
-    
+
     var ins;
     var outs;
-    
+
     function onMIDIFailure(msg){
       console.log("Failed to get MIDI access - " + msg);
     }
-    
+
     function onMIDISuccess(midiAccess){
       midi = midiAccess;
       ins = midi.inputs();
       outs = midi.outputs();
       setTimeout(testOutputs, 200);
     }
-    
+
     function testOutputs(){
       console.log('Testing MIDI-Out ports...');
       for(var i in outs){
@@ -68,20 +68,20 @@ You can also take a look at [index.html](http://cwilso.github.com/WebMIDIAPIShim
       }
       setTimeout(stopOutputs, 1000);
     }
-    
+
     function stopOutputs(){
       for(var i in outs){
         outs[i].send([0x80, 60, 0]);
       }
       testInputs();
     }
-    
+
     function onMidiIn(ev){
       var arr = [];
       for(var i=0; i<ev.data.length; i++) arr.push((ev.data[i]<16 ? '0' : '') + ev.data[i].toString(16));
       console.log('MIDI:', arr.join(' '));
     }
-    
+
     function testInputs(){
       console.log('Testing MIDI-In ports...');
       for(var i in ins){
@@ -91,10 +91,10 @@ You can also take a look at [index.html](http://cwilso.github.com/WebMIDIAPIShim
       }
       setTimeout(stopInputs, 5000);
     }
-    
+
     function stopInputs(){
       console.log('Thank you!');
       navigator.close(); // This will close MIDI inputs, otherwise Node.js will wait for MIDI input forever.
     }
-    
+
     navigator.requestMIDIAccess().then(onMIDISuccess,onMIDIFailure);

--- a/README.md
+++ b/README.md
@@ -44,13 +44,23 @@ So, some sample usage:
 
 You can also take a look at [index.html](http://cwilso.github.com/WebMIDIAPIShim/tests/index.html) for a basic test, or [multi.html](http://cwilso.github.com/WebMIDIAPIShim/tests/multi.html) or [routing.html](http://cwilso.github.com/WebMIDIAPIShim/tests/routing.html) for a multiple-simultaneous-input test.  Better documentation later.  :)
 
-##Node.js install
+##Node.js install and test
+
+  Make a new directory, copy the file test.js to this directory. Then move into the newly created directory via the command line and enter this command:
 
     npm install web-midi-api
 
-##Node.js example
+  Now you should have a folder node_modules/web-midi-api. Type this command to run the test:
 
-    var navigator = require('web-midi-api');
+    node test.js
+
+  Or if you are on Linux:
+
+    nodejs test.js
+
+##Node.js example (test.js)
+
+    var navigator = require('../web-midi-api');
 
     var midi;
     var inputs;

--- a/WebMIDIAPI.js
+++ b/WebMIDIAPI.js
@@ -331,7 +331,7 @@
         } else {
             inputInstance.inputInUse = true;
             //inputInstance._delayedInit(then.bind(this));
-            // no need to delay, the instance has already been initialized
+            // no need for delay, the instance has already been initialized
             then.call(this);
         }
     };
@@ -520,7 +520,7 @@
         } else {
             outputInstance.outputInUse = true;
             //outputInstance._delayedInit(then.bind(this));
-            // no need to delay, the instance has already been initialized
+            // no need for delay, the instance has already been initialized
             then.call(this);
         }
     };

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@ function success( midiAccess ) {
     var i, iterator, data, port;
 
     log.innerHTML += "MIDI ready!\n";
-    midi = midiAccess;
+    midi = window.updateMIDIAccess(midiAccess);
 
     inputs = midi.inputs;
     log.innerHTML += inputs.size+" inputs:\n";

--- a/index.html
+++ b/index.html
@@ -75,29 +75,58 @@ function handleMIDIMessage( ev ) {
 }
 
 function success( midiAccess ) {
-	log.innerHTML += "MIDI ready!\n";
-	midi = midiAccess;
+    var i, iterator, data, port;
 
-	inputs = midi.inputs();
-	log.innerHTML += inputs.length+" inputs:\n";
-	for (var i=0;i<inputs.length;i++)
-		log.innerHTML += i + ": " + inputs[i].name + "; manufacturer: " + inputs[i].manufacturer + "; version: " + inputs[i].version + "\n";
+    log.innerHTML += "MIDI ready!\n";
+    midi = midiAccess;
 
-	if (inputs.length>0) {
-		input = inputs[0];
-//		input.onmidimessage = handleMIDIMessage;
-		input.addEventListener("midimessage", handleMIDIMessage);
-		log.innerHTML += "Hooked up first input.\n";
-	}
+    inputs = midi.inputs;
+    log.innerHTML += inputs.size+" inputs:\n";
 
-	outputs = midi.outputs();
-	log.innerHTML += outputs.length+" outputs:\n";
-	for (var i=0;i<outputs.length;i++)
-		log.innerHTML += i + ": " + outputs[i].name + "; manufacturer: " + outputs[i].manufacturer + "; version: " + outputs[i].version + "\n";
+/*
+    // forEach doesn't yet work in WebMIDI/Chrome...
+    i = 0;
+    inputs.forEach(function(key, value){
+        log.innerHTML += i++ + ": " + value.name + "; manufacturer: " + value.manufacturer + "; version: " + value.version + "\n";
+    });
+*/
 
-	if (outputs.length) {
-		output = outputs[0];
-		output.send( [0xb0, 0x00, 0x7f] );	// If the first device is a Novation Launchpad, this will light it up!
+    // ...but the iterator does, so we use the iterator:
+    i = 0;
+    iterator = inputs.values();
+    while((data = iterator.next()).done === false){
+        port = data.value;
+        log.innerHTML += i++ + ": " + port.name + "; manufacturer: " + port.manufacturer + "; version: " + port.version + "\n";
+    }
+
+    if(inputs.size > 0) {
+        iterator = inputs.values();
+        input = iterator.next().value;
+        // input.onmidimessage = handleMIDIMessage;
+        input.addEventListener("midimessage", handleMIDIMessage);
+        log.innerHTML += "Hooked up first input.\n";
+    }
+
+    outputs = midi.outputs;
+    log.innerHTML += outputs.size+" outputs:\n";
+
+/*
+    i = 0;
+    outputs.forEach(function(key, value){
+        log.innerHTML += i++ + ": " + value.name + "; manufacturer: " + value.manufacturer + "; version: " + value.version + "\n";
+    });
+*/
+    i = 0;
+    iterator = outputs.values();
+    while((data = iterator.next()).done === false){
+        port = data.value;
+        log.innerHTML += i++ + ": " + port.name + "; manufacturer: " + port.manufacturer + "; version: " + port.version + "\n";
+    }
+
+    if(outputs.size > 0) {
+        iterator = outputs.values();
+		output = iterator.next().value;
+        output.send( [0xb0, 0x00, 0x7f] );  // If the first device is a Novation Launchpad, this will light it up!
 	}
 }
 

--- a/index.html
+++ b/index.html
@@ -84,33 +84,14 @@ function success( midiAccess ) {
     log.innerHTML += inputs.size+" inputs:\n";
 
 /*
-    // forEach doesn't yet work in WebMIDI/Chrome...
+    // forEach doesn't yet work in WebMIDI/Chrome
     i = 0;
     inputs.forEach(function(key, value){
         log.innerHTML += i++ + ": " + value.name + "; manufacturer: " + value.manufacturer + "; version: " + value.version + "\n";
     });
 */
 
-    // ...but the iterator does, so we use the iterator:
-
-iterator = inputs.keys();
-while((data = iterator.next()).done !== true){
-    console.log('input id:', data.value, inputs.has(data.value), inputs.get(data.value).name);
-}
-
-iterator = inputs.values();
-while((data = iterator.next()).done !== true){
-    port = data.value;
-    console.log('input id:', port.id, ' input name:', port.name);
-}
-
-iterator = inputs.entries();
-while((data = iterator.next()).done !== true){
-    port = data.value[1];
-    console.log('input id:', port.id, data.value[0], ' input name:', port.name);
-}
-
-
+    // but the iterator does, so we use the iterator:
     i = 0;
     iterator = inputs.values();
     while((data = iterator.next()).done === false){

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@ function success( midiAccess ) {
     var i, iterator, data, port;
 
     log.innerHTML += "MIDI ready!\n";
-    midi = window.updateMIDIAccess(midiAccess);
+    midi = midiAccess;
 
     inputs = midi.inputs;
     log.innerHTML += inputs.size+" inputs:\n";

--- a/index.html
+++ b/index.html
@@ -92,6 +92,25 @@ function success( midiAccess ) {
 */
 
     // ...but the iterator does, so we use the iterator:
+
+iterator = inputs.keys();
+while((data = iterator.next()).done !== true){
+    console.log('input id:', data.value, inputs.has(data.value), inputs.get(data.value).name);
+}
+
+iterator = inputs.values();
+while((data = iterator.next()).done !== true){
+    port = data.value;
+    console.log('input id:', port.id, ' input name:', port.name);
+}
+
+iterator = inputs.entries();
+while((data = iterator.next()).done !== true){
+    port = data.value[1];
+    console.log('input id:', port.id, data.value[0], ' input name:', port.name);
+}
+
+
     i = 0;
     iterator = inputs.values();
     while((data = iterator.next()).done === false){

--- a/test.js
+++ b/test.js
@@ -1,34 +1,37 @@
 // This script is for Node.js only. Don't use it in HTML!
-var navigator = require('../web-midi-api');
+'use strict';
 
-var ins;
-var outs;
+var navigator = require('web-midi-api');
+
+var midi;
+var inputs;
+var outputs;
 
 function onMIDIFailure(msg){
-  console.log("Failed to get MIDI access - " + msg);
+  console.log('Failed to get MIDI access - ' + msg);
 }
 
 function onMIDISuccess(midiAccess){
   midi = midiAccess;
-  ins = midi.inputs();
-  outs = midi.outputs();
+  inputs = midi.inputs;
+  outputs = midi.outputs;
   setTimeout(testOutputs, 500);
 }
 
 function testOutputs(){
   console.log('Testing MIDI-Out ports...');
-  for(var i in outs){
-    var x = outs[i];
-    console.log('id:', x.id, "manufacturer:", x.manufacturer, "name:", x.name, "version:", x.version);
+  outputs.forEach(function(key, value){
+    var x = value;
+    console.log('id:', x.id, 'manufacturer:', x.manufacturer, 'name:', x.name, 'version:', x.version);
     x.send([0x90, 60, 0x7f]);
-  }
+  });
   setTimeout(stopOutputs, 1000);
 }
 
 function stopOutputs(){
-  for(var i in outs){
-    outs[i].send([0x80, 60, 0]);
-  }
+  outputs.forEach(function(key, value){
+    value.send([0x80, 60, 0]);
+  });
   testInputs();
 }
 
@@ -40,11 +43,11 @@ function onMidiIn(ev){
 
 function testInputs(){
   console.log('Testing MIDI-In ports...');
-  for(var i in ins){
-    var x = ins[i];
-    console.log('id:', x.id, "manufacturer:", x.manufacturer, "name:", x.name, "version:", x.version);
+  inputs.forEach(function(key, value){
+    var x = value;
+    console.log('id:', x.id, 'manufacturer:', x.manufacturer, 'name:', x.name, 'version:', x.version);
     x.onmidimessage = onMidiIn;
-  }
+  });
   setTimeout(stopInputs, 5000);
 }
 

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 // This script is for Node.js only. Don't use it in HTML!
 'use strict';
 
-var navigator = require('web-midi-api');
+var navigator = require('../web-midi-api');
 
 var midi;
 var inputs;

--- a/tests/MIDITest.html
+++ b/tests/MIDITest.html
@@ -3,6 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
 <title>Web MIDI test</title>
+<script src="../WebMIDIAPI.js"></script>
 <script>
 var midi=null;
 var inputs=null;
@@ -12,46 +13,60 @@ var output=null;
 var log=null;
 
 function runTest() {
-	if (!log)
+	if (!log){
 		log = document.getElementById("log");
-	log.innerText = "Starting up MIDI...\n";
+	}
+	log.textContent = "Starting up MIDI...\n";
 	navigator.requestMIDIAccess().then( success, failure );
 }
 
 function handleMIDIMessage( ev ) {
 	// testing - just reflect.
-	log.innerText += "Message: " + ev.data.length + " bytes, timestamp: " + ev.timestamp;
-	if (ev.data.length == 3) 
-		log.innerText += " 0x" + ev.data[0].toString(16) + " 0x" + ev.data[1].toString(16) + " 0x" + ev.data[2].toString(16);
+	log.textContent += "Message: " + ev.data.length + " bytes, timestamp: " + ev.timestamp;
+	if (ev.data.length == 3)
+		log.textContent += " 0x" + ev.data[0].toString(16) + " 0x" + ev.data[1].toString(16) + " 0x" + ev.data[2].toString(16);
 	if (output) {
 		output.send( ev.data );
-		log.innerText += " reflected to output '" + output.name + "'";
+		log.textContent += " reflected to output '" + output.name + "'";
 	}
-	log.innerText += "\n";
+	log.textContent += "\n";
 }
 
 function success( midiAccess ) {
-	log.innerText += "MIDI ready!\n";
+	var i, iterator;
+	log.textContent += "MIDI ready!\n";
 	midi = midiAccess;
 
-	inputs = midi.inputs();
-	log.innerText += inputs.length+" inputs:\n";
-	for (var i=0;i<inputs.length;i++)
-		log.innerText += i + ": " + inputs[i].name + "\n";
+	inputs = midi.inputs;
+	log.textContent += inputs.size+" inputs:\n";
 
-	if (inputs.length>0) {
-		input = inputs[0];
+	i = 0;
+    iterator = inputs.values();
+    while((data = iterator.next()).done === false){
+        port = data.value;
+        log.innerHTML += i++ + ": " + port.name + "; manufacturer: " + port.manufacturer + "; version: " + port.version + "\n";
+    }
+
+	if (inputs.size>0) {
+		iterator = inputs.values();
+		input = iterator.next().value;
 		input.onmidimessage = handleMIDIMessage;
-		log.innerText += "Hooked up first input: " + input.name + ".\n";
+		log.textContent += "Hooked up first input: " + input.name + ".\n";
 	}
 
-	outputs = midi.outputs();
-	log.innerText += outputs.length+" outputs:\n";
-	for (var i=0;i<outputs.length;i++)
-		log.innerText += i + ": " + outputs[i].name + "\n";
+	outputs = midi.outputs;
+	log.textContent += outputs.size+" outputs:\n";
 
-	if (outputs.length) {
-		output = outputs[0];
+	i = 0;
+    iterator = outputs.values();
+    while((data = iterator.next()).done === false){
+        port = data.value;
+        log.innerHTML += i++ + ": " + port.name + "; manufacturer: " + port.manufacturer + "; version: " + port.version + "\n";
+    }
+
+	if (outputs.size > 0) {
+		iterator = outputs.values();
+		output = iterator.next().value;
 	}
 }
 

--- a/tests/MIDITest.html
+++ b/tests/MIDITest.html
@@ -35,7 +35,7 @@ function handleMIDIMessage( ev ) {
 function success( midiAccess ) {
 	var i, iterator;
 	log.textContent += "MIDI ready!\n";
-	midi = midiAccess;
+	midi = window.updateMIDIAccess(midiAccess);
 
 	inputs = midi.inputs;
 	log.textContent += inputs.size+" inputs:\n";

--- a/tests/MIDITest.html
+++ b/tests/MIDITest.html
@@ -35,7 +35,7 @@ function handleMIDIMessage( ev ) {
 function success( midiAccess ) {
 	var i, iterator;
 	log.textContent += "MIDI ready!\n";
-	midi = window.updateMIDIAccess(midiAccess);
+	midi = midiAccess;
 
 	inputs = midi.inputs;
 	log.textContent += inputs.size+" inputs:\n";

--- a/tests/MIDITest.html
+++ b/tests/MIDITest.html
@@ -44,7 +44,7 @@ function success( midiAccess ) {
     iterator = inputs.values();
     while((data = iterator.next()).done === false){
         port = data.value;
-        log.innerHTML += i++ + ": " + port.name + "; manufacturer: " + port.manufacturer + "; version: " + port.version + "\n";
+        log.textContent += i++ + ": " + port.name + "; manufacturer: " + port.manufacturer + "; version: " + port.version + "\n";
     }
 
 	if (inputs.size>0) {
@@ -61,7 +61,7 @@ function success( midiAccess ) {
     iterator = outputs.values();
     while((data = iterator.next()).done === false){
         port = data.value;
-        log.innerHTML += i++ + ": " + port.name + "; manufacturer: " + port.manufacturer + "; version: " + port.version + "\n";
+        log.textContent += i++ + ": " + port.name + "; manufacturer: " + port.manufacturer + "; version: " + port.version + "\n";
     }
 
 	if (outputs.size > 0) {

--- a/tests/index.html
+++ b/tests/index.html
@@ -32,7 +32,7 @@ function handleMIDIMessage( ev ) {
 function success( midiAccess ) {
 	var i, iterator, data, port;
 	log.textContent += "MIDI ready!\n";
-	midi = midiAccess;
+	midi = window.updateMIDIAccess(midiAccess);
 
 	inputs = midi.inputs;
 	log.textContent += inputs.size+" inputs:\n";

--- a/tests/index.html
+++ b/tests/index.html
@@ -41,7 +41,7 @@ function success( midiAccess ) {
     iterator = inputs.values();
     while((data = iterator.next()).done === false){
         port = data.value;
-        log.innerHTML += i++ + ": " + port.name + "; manufacturer: " + port.manufacturer + "; version: " + port.version + "\n";
+        log.textContent += i++ + ": " + port.name + "; manufacturer: " + port.manufacturer + "; version: " + port.version + "\n";
     }
 
 	if (inputs.size>0) {
@@ -59,7 +59,7 @@ function success( midiAccess ) {
     iterator = outputs.values();
     while((data = iterator.next()).done === false){
         port = data.value;
-        log.innerHTML += i++ + ": " + port.name + "; manufacturer: " + port.manufacturer + "; version: " + port.version + "\n";
+        log.textContent += i++ + ": " + port.name + "; manufacturer: " + port.manufacturer + "; version: " + port.version + "\n";
     }
 
 	if (outputs.size > 0) {

--- a/tests/index.html
+++ b/tests/index.html
@@ -15,44 +15,58 @@ var log=null;
 function runTest() {
 	if (!log)
 		log = document.getElementById("log");
-	log.innerText = "Starting up MIDI...\n";
+	log.textContent = "Starting up MIDI...\n";
 	navigator.requestMIDIAccess().then( success, failure );
 }
 
 function handleMIDIMessage( ev ) {
 	// testing - just reflect.
-	log.innerText += "Message: " + ev.data.length + " bytes, timestamp: " + ev.timestamp;
-	if (ev.data.length == 3) 
-		log.innerText += " 0x" + ev.data[0].toString(16) + " 0x" + ev.data[1].toString(16) + " 0x" + ev.data[2].toString(16);
-	log.innerText += "\n";
+	log.textContent += "Message: " + ev.data.length + " bytes, timestamp: " + ev.timestamp;
+	if (ev.data.length == 3)
+		log.textContent += " 0x" + ev.data[0].toString(16) + " 0x" + ev.data[1].toString(16) + " 0x" + ev.data[2].toString(16);
+	log.textContent += "\n";
 	if (output)
 		output.send( ev.data );
 }
 
 function success( midiAccess ) {
-	log.innerText += "MIDI ready!\n";
+	var i, iterator, data, port;
+	log.textContent += "MIDI ready!\n";
 	midi = midiAccess;
 
-	inputs = midi.inputs();
-	log.innerText += inputs.length+" inputs:\n";
-	for (var i=0;i<inputs.length;i++)
-		log.innerText += i + ": " + inputs[i].name + "\n";
+	inputs = midi.inputs;
+	log.textContent += inputs.size+" inputs:\n";
 
-	if (inputs.length>0) {
-		input = inputs[0];
+	i = 0;
+    iterator = inputs.values();
+    while((data = iterator.next()).done === false){
+        port = data.value;
+        log.innerHTML += i++ + ": " + port.name + "; manufacturer: " + port.manufacturer + "; version: " + port.version + "\n";
+    }
+
+	if (inputs.size>0) {
+		iterator = inputs.values();
+		input = iterator.next().value;
 //		input.onmessage = handleMIDIMessage;
 		input.addEventListener("midimessage", handleMIDIMessage);
-		log.innerText += "Hooked up first input.\n";
+		log.textContent += "Hooked up first input.\n";
 	}
 
-	outputs = midi.outputs();
-	log.innerText += outputs.length+" outputs:\n";
-	for (var i=0;i<outputs.length;i++)
-		log.innerText += i + ": " + outputs[i].name + "\n";
+	outputs = midi.outputs;
+	log.textContent += outputs.size+" outputs:\n";
 
-	if (outputs.length) {
-		output = outputs[0];
-		output.send( [0xb0, 0x00, 0x7f] );	// If the first device is a Novation Launchpad, this will light it up!
+	i = 0;
+    iterator = outputs.values();
+    while((data = iterator.next()).done === false){
+        port = data.value;
+        log.innerHTML += i++ + ": " + port.name + "; manufacturer: " + port.manufacturer + "; version: " + port.version + "\n";
+    }
+
+	if (outputs.size > 0) {
+		iterator = outputs.values();
+		output = iterator.next().value;
+		//output.send( [0xb0, 0x00, 0x7f] );	// If the first device is a Novation Launchpad, this will light it up!
+		output.send( [0x90, 60, 100] );	// If the first device is a synth, you will hear a note
 	}
 }
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -32,7 +32,7 @@ function handleMIDIMessage( ev ) {
 function success( midiAccess ) {
 	var i, iterator, data, port;
 	log.textContent += "MIDI ready!\n";
-	midi = window.updateMIDIAccess(midiAccess);
+	midi = midiAccess;
 
 	inputs = midi.inputs;
 	log.textContent += inputs.size+" inputs:\n";

--- a/tests/multi.html
+++ b/tests/multi.html
@@ -35,10 +35,10 @@ function handleMIDIMessage2( ev ) {
 		output.send( ev.data );
 }
 
-function success( m ) {
+function success( midiAccess ) {
 	var i, iterator, data, port;
 	log.textContent += "MIDI ready!\n";
-	midi = m;
+	midi = window.updateMIDIAccess(midiAccess);
 
 	inputs = midi.inputs;
 	log.textContent += inputs.size+" inputs:\n";

--- a/tests/multi.html
+++ b/tests/multi.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
 <head>
+	<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
 	<title>Test of multiple inputs</title>
 	<script src="../WebMIDIAPI.js"></script>
 	<script>
@@ -38,7 +39,7 @@ function handleMIDIMessage2( ev ) {
 function success( midiAccess ) {
 	var i, iterator, data, port;
 	log.textContent += "MIDI ready!\n";
-	midi = window.updateMIDIAccess(midiAccess);
+	midi = midiAccess;
 
 	inputs = midi.inputs;
 	log.textContent += inputs.size+" inputs:\n";

--- a/tests/multi.html
+++ b/tests/multi.html
@@ -48,13 +48,11 @@ function success( midiAccess ) {
     iterator = inputs.values();
     while((data = iterator.next()).done === false){
         port = data.value;
-        log.innerHTML += i++ + ": " + port.name + "; manufacturer: " + port.manufacturer + "; version: " + port.version + "\n";
+        log.textContent += i++ + ": " + port.name + "; manufacturer: " + port.manufacturer + "; version: " + port.version + "\n";
     }
 
 	if (inputs.size>=2) {
 		iterator = inputs.values();
-		iterator.next()
-		iterator.next()
 		input1 = iterator.next().value;
 		input1.addEventListener( "midimessage", handleMIDIMessage1 );
 		log.textContent += "Hooked up first input.\n";
@@ -70,7 +68,7 @@ function success( midiAccess ) {
     iterator = outputs.values();
     while((data = iterator.next()).done === false){
         port = data.value;
-        log.innerHTML += i++ + ": " + port.name + "; manufacturer: " + port.manufacturer + "; version: " + port.version + "\n";
+        log.textContent += i++ + ": " + port.name + "; manufacturer: " + port.manufacturer + "; version: " + port.version + "\n";
     }
 
 	if (outputs.size > 0) {

--- a/tests/multi.html
+++ b/tests/multi.html
@@ -15,14 +15,14 @@ var log=null;
 function runTest() {
 	if (!log)
 		log = document.getElementById("log");
-	log.innerText = "Starting up MIDI...\n";
+	log.textContent = "Starting up MIDI...\n";
 	navigator.requestMIDIAccess().then( success, failure );
 }
 
 function handleMIDIMessage1( ev ) {
 	// testing - just reflect.
 	if (ev.data.length == 3)
-		log.innerText += "Message on input 1: 0x" + ev.data[0].toString(16) + " 0x" + ev.data[1].toString(16) + " 0x" + ev.data[2].toString(16) + "\n";
+		log.textContent += "Message on input 1: 0x" + ev.data[0].toString(16) + " 0x" + ev.data[1].toString(16) + " 0x" + ev.data[2].toString(16) + "\n";
 	if (output)
 		output.send( ev.data );
 }
@@ -30,38 +30,53 @@ function handleMIDIMessage1( ev ) {
 function handleMIDIMessage2( ev ) {
 	// testing - just reflect.
 	if (ev.data.length == 3)
-		log.innerText += "Message on input 2: 0x" + ev.data[0].toString(16) + " 0x" + ev.data[1].toString(16) + " 0x" + ev.data[2].toString(16) + "\n";
+		log.textContent += "Message on input 2: 0x" + ev.data[0].toString(16) + " 0x" + ev.data[1].toString(16) + " 0x" + ev.data[2].toString(16) + "\n";
 	if (output)
 		output.send( ev.data );
 }
 
 function success( m ) {
-	log.innerText += "MIDI ready!\n";
+	var i, iterator, data, port;
+	log.textContent += "MIDI ready!\n";
 	midi = m;
 
-	inputs = midi.inputs();
-	log.innerText += inputs.length+" inputs:\n";
-	for (var i=0;i<inputs.length;i++)
-		log.innerText += i + ": " + inputs[i].name + "\n";
+	inputs = midi.inputs;
+	log.textContent += inputs.size+" inputs:\n";
 
-	if (inputs.length>=2) {
-		input1 = inputs[0];
-		input1.onmidimessage = handleMIDIMessage1;
-		log.innerText += "Hooked up first input.\n";
-		input2 = inputs[1];
+	i = 0;
+    iterator = inputs.values();
+    while((data = iterator.next()).done === false){
+        port = data.value;
+        log.innerHTML += i++ + ": " + port.name + "; manufacturer: " + port.manufacturer + "; version: " + port.version + "\n";
+    }
+
+	if (inputs.size>=2) {
+		iterator = inputs.values();
+		iterator.next()
+		iterator.next()
+		input1 = iterator.next().value;
+		input1.addEventListener( "midimessage", handleMIDIMessage1 );
+		log.textContent += "Hooked up first input.\n";
+		input2 = iterator.next().value;
 		input2.addEventListener( "midimessage", handleMIDIMessage2 );
-		log.innerText += "Hooked up second input.\n";
+		log.textContent += "Hooked up second input.\n";
 	}
 
-	outputs = midi.outputs();
-	log.innerText += outputs.length+" outputs:\n";
-	for (var i=0;i<outputs.length;i++)
-		log.innerText += i + ": " + outputs[i].name + "\n";
+	outputs = midi.outputs;
+	log.textContent += outputs.size+" outputs:\n";
 
-	if (outputs.length) {
-		output = outputs[0];
-		output.send( [0xb0, 0x00, 0x7f] );	// If the first device is a Novation Launchpad, this will light it up!
-		output = outputs[outputs.length-1];
+	i = 0;
+    iterator = outputs.values();
+    while((data = iterator.next()).done === false){
+        port = data.value;
+        log.innerHTML += i++ + ": " + port.name + "; manufacturer: " + port.manufacturer + "; version: " + port.version + "\n";
+    }
+
+	if (outputs.size > 0) {
+		iterator = outputs.values();
+		output = iterator.next().value;
+		//output.send( [0xb0, 0x00, 0x7f] ); // If the first device is a Novation Launchpad, this will light it up!
+		output.send( [0x90, 60, 100] );	// If the first device is a synth, you will hear a note
 	}
 }
 

--- a/tests/routing.html
+++ b/tests/routing.html
@@ -45,7 +45,7 @@ window.onload = function(){
 
 
     function runTest() {
-        preLog.textContent = 'Starting up MIDI...\n';
+        preLog.innerHTML = 'Starting up MIDI...\n';
         navigator.requestMIDIAccess().then(success, failure);
     }
 
@@ -59,7 +59,7 @@ window.onload = function(){
         if(ev.data.length === 3){
             output = output + ' 0x' + ev.data[0].toString(16) + ' 0x' + ev.data[1].toString(16) + ' 0x' + ev.data[2].toString(16);
         }
-        preLog.textContent = output + '\n' + preLog.textContent;
+        preLog.innerHTML = output + '\n' + preLog.innerHTML;
 
         for(var id in activeOutputs){
             activeOutputs[id].send(ev.data);
@@ -69,7 +69,7 @@ window.onload = function(){
 
     function success(midiAccess) {
         var i, maxi, iterator, data, port, portId, checkboxes, checkbox;
-        preLog.textContent += 'MIDI ready!\n';
+        preLog.innerHTML += 'MIDI ready!\n';
         midi = midiAccess;
 
         inputs = midi.inputs;

--- a/tests/routing.html
+++ b/tests/routing.html
@@ -7,6 +7,7 @@
     #container{
         width: 100%;
         font-family: monospace;
+        visibility: hidden;
     }
     #inputs{
         float: left;
@@ -38,6 +39,7 @@ window.onload = function(){
         btnRun = document.getElementById('run_test'),
         divInputs = document.getElementById('inputs'),
         divOutputs = document.getElementById('outputs'),
+        divContainer = document.getElementById('container'),
         midi = null,
         inputs = null,
         outputs = null,
@@ -45,6 +47,7 @@ window.onload = function(){
 
 
     function runTest() {
+        divContainer.style.visibility = 'visible';
         preLog.innerHTML = 'Starting up MIDI...\n';
         navigator.requestMIDIAccess().then(success, failure);
     }

--- a/tests/test2.html
+++ b/tests/test2.html
@@ -1,0 +1,152 @@
+<!doctype html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<title>Web MIDI API Polyfill</title>
+<style>
+    #container{
+        width: 100%;
+        font-family: monospace;
+    }
+    #inputs{
+        float: left;
+        margin-right: 50px;
+    }
+    #outputs{
+        float: left;
+    }
+
+    /*clearfix*/
+    .cf:before,
+    .cf:after {
+        content: " ";
+        display: table;
+    }
+    .cf:after {
+        clear: both;
+    }
+</style>
+<script src="../WebMIDIAPI.js"></script>
+<script>
+
+window.onload = function(){
+
+    'use strict';
+
+    var
+        preLog = document.getElementById('log'),
+        btnRun = document.getElementById('run_test'),
+        divInputs = document.getElementById('inputs'),
+        divOutputs = document.getElementById('outputs'),
+        midi = null,
+        inputs = null,
+        outputs = null,
+        activeOutputs = {};
+
+
+    function runTest() {
+        preLog.textContent = 'Starting up MIDI...\n';
+        navigator.requestMIDIAccess().then(success, failure);
+    }
+
+
+    function handleMIDIMessage(ev) {
+        // testing - just reflect.
+        var output = 'Message from input ' + this.name + ': ' + ev.data.length + ' bytes';
+        if(ev.timestamp){
+            output = output += ', timestamp: ' + ev.timestamp;
+        }
+        if(ev.data.length === 3){
+            output = output + ' 0x' + ev.data[0].toString(16) + ' 0x' + ev.data[1].toString(16) + ' 0x' + ev.data[2].toString(16);
+        }
+        preLog.textContent = output + '\n' + preLog.textContent;
+
+        for(var id in activeOutputs){
+            activeOutputs[id].send(ev.data);
+        }
+    }
+
+
+    function success(midiAccess) {
+        var i, maxi, iterator, data, port, portId, checkboxes, checkbox;
+        preLog.textContent += 'MIDI ready!\n';
+        midi = midiAccess;
+
+        inputs = midi.inputs;
+        iterator = inputs.values();
+        while((data = iterator.next()).done === false){
+            port = data.value;
+            checkbox = '<label><input type="checkbox" value="' + port.id + '">' + port.name + '</label>';
+            divInputs.innerHTML += checkbox + '<br>';
+        }
+
+        checkboxes = document.querySelectorAll('#inputs input[type="checkbox"]');
+
+        for(i = 0, maxi = checkboxes.length; i < maxi; i++){
+            checkbox = checkboxes[i];
+            checkbox.addEventListener('change', function(){
+                portId = this.value;
+                if(inputs.has(portId)){
+                    port = inputs.get(portId);
+                    if(this.checked === true){
+                        port.addEventListener('midimessage', handleMIDIMessage);
+                    }else{
+                        port.removeEventListener('midimessage', handleMIDIMessage);
+                    }
+                }
+            }, false);
+        }
+
+        outputs = midi.outputs;
+        iterator = outputs.values();
+        while((data = iterator.next()).done === false){
+            port = data.value;
+            checkbox = '<label><input type="checkbox" value="' + port.id + '">' + port.name + '</label>';
+            divOutputs.innerHTML += checkbox + '<br>';
+        }
+
+        checkboxes = document.querySelectorAll('#outputs input[type="checkbox"]');
+
+        for(i = 0, maxi = checkboxes.length; i < maxi; i++){
+            checkbox = checkboxes[i];
+            checkbox.addEventListener('change', function(){
+                portId = this.value;
+                if(outputs.has(portId)){
+                    port = outputs.get(portId);
+                    if(this.checked === true){
+                        activeOutputs[port.name + port.id] = port;
+                    }else{
+                        delete activeOutputs[port.name + port.id];
+                    }
+                }
+            }, false);
+        }
+    }
+
+
+    function failure(error) {
+        alert('Failed to initialize MIDI - ' + ((error.code === 1) ? 'permission denied' : ('error code ' + error.code)));
+    }
+
+
+    btnRun.addEventListener('click', function(){
+        runTest();
+    }, false);
+
+};
+</script>
+</head>
+
+<body>
+    <button id="run_test">Test MIDI!</button>
+    <div id="container">
+        <p>Select one or more inputs. The incoming MIDI messages will be routed the selected output(s).</p>
+        <div class="cf">
+            <div id="inputs"></div>
+            <div id="outputs"></div>
+        </div>
+        <pre id="log"></pre>
+    </div>
+    <div id="MIDIPlugin" style="position:absolute; visibility:hidden"></div>
+</body>
+</html>


### PR DESCRIPTION
In short:
- the shim has been updated according to the latest draft: MIDIAccess.inputs and MIDIAccess.outputs are now objects that mimic MIDIInputMap resp. MIDIOutputMap
- added a class Iterator
- added a wrapper for Chromium's WebMIDI implementation
- moved the _requestMIDIAccess method to a self-invoking init method
- updated all examples
- added a new routing example
- replaced innerText with textContent in all examples
- updated the README according to the new WebMIDI API
- updated the link to the W3C WebMIDI API draft in the README file
- added link to new routing example in the README file

MIDIAccess.inputs and MIDIAccess.outputs are still implemented as functions in Chromium. Therefor I have also added a wrapper for Chromium's WebMIDI implementation, see the init method.

According to the new draft it should be possible to loop over inputs and outputs like so:

```
MIDIAccess.inputs.forEach(function(key, value){
    console.log('input id:', key, ' input name:', value.name);
});
```

But in Chrome's WebMIDI implementation this doesn't work yet. The functionality is implemented in the shim and works correctly but to make the examples work with both the Jazz plugin and native WebMIDI, I have used the iterator in the web examples to loop over inputs and outputs:

```
var iterator = MIDIAccess.inputs.values();
var data;
while((data = iterator.next()).done !== true){
    port = data.value;
    console.log('input id:', port.id, ' input name:', port.name);
}
```
