### PR TITLE
MIDIInput.removeEventListener is broken

### DIFF
--- a/src/midi_input.js
+++ b/src/midi_input.js
@@ -66,7 +66,7 @@ export class MIDIInput{
       return;
     }
 
-    if(listeners.has(listener) === false){
+    if(listeners.has(listener) === true){
       listeners.delete(listener);
     }
   }


### PR DESCRIPTION
The current implementation of `removeEventListener` causes the listeners to never be removed.
`listeners.has(listener)` should be true in case you want to delete the listener.