### PR TITLE
MIDIOutput.removeEventListener is broken

### DIFF
--- a/src/midi_output.js
+++ b/src/midi_output.js
@@ -94,7 +94,7 @@ export class MIDIOutput{
       return;
     }
 
-    if(this._listeners.has(listener) === false){
+    if(this._listeners.has(listener) === true){
       this._listeners.delete(listener);
     }
   }


### PR DESCRIPTION
The current implementation of `removeEventListener` causes the listeners to never be removed.
`listeners.has(listener)` should be true in case you want to delete the listener.