### PR TITLE
Export MIDI items via node/index.js. Resolves #78.

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -7,3 +7,9 @@ global.navigator = {
     jazzMidi,
 };
 require('../dist/index.js');
+exports.requestMIDIAccess = navigator.requestMIDIAccess;
+exports.MIDIInput = navigator.MIDIInput;
+exports.MIDIOutput = navigator.MIDIOutput;
+exports.MIDIMessageEvent = navigator.MIDIMessageEvent;
+exports.MIDIConnectionEvent = navigator.MIDIConnectionEvent;
+exports.close = navigator.close;


### PR DESCRIPTION
This patch re-exports the goods that get monkeypatched into the global navigator. This should make it possible for Node.js users to consume this package in a normative Node.js npm package manner.